### PR TITLE
Update to cover GKE sceneario

### DIFF
--- a/podinfo/podinfo-svc.yaml
+++ b/podinfo/podinfo-svc.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app: podinfo
 spec:
+# To get this running in GKE you have to set type to LoadBalancer
+# and remove protocol and nodePort properties
   type: NodePort
   ports:
     - port: 9898


### PR DESCRIPTION
I don't think NodePort is supported by GKE, I didn't get it working.  When changing to LoadBalancer and removing the two properties it worked for me. Added comment about it