### PR TITLE
Add needed rights to the custom-metrics-resource-reader role

### DIFF
--- a/custom-metrics-api/custom-metrics-resource-reader-cluster-role.yaml
+++ b/custom-metrics-api/custom-metrics-resource-reader-cluster-role.yaml
@@ -6,9 +6,11 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
   - namespaces
   - pods
   - services
   verbs:
   - get
+  - watch
   - list


### PR DESCRIPTION
I needed to grant the custom-metrics-resource-reader role access to node resources and the watch verb so that the autoscaler could read those stats.