### PR TITLE
Update to k8s 1.18 api v2beta2

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ kubectl create -f ./prometheus
 Generate the TLS certificates needed by the Prometheus adapter:
 
 ```bash
+touch metrics-ca.key metrics-ca.crt metrics-ca-config.json
 make certs
 ```
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta1" | jq .
 Get the FS usage for all the pods in the `monitoring` namespace:
 
 ```bash
-kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta1/namespaces/monitoring/pods/*/fs_usage_bytes" | jq .
+kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta1/namespaces/monitoring/pods/*/kubelet_container_log_filesystem_used_bytes" | jq .
 ```
 
 ### Auto Scaling based on custom metrics

--- a/README.md
+++ b/README.md
@@ -261,13 +261,13 @@ The `m` represents `milli-units`, so for example, `901m` means 901 milli-request
 Create a HPA that will scale up the `podinfo` deployment if the number of requests goes over 10 per second:
 
 ```yaml
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: podinfo
 spec:
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: podinfo
   minReplicas: 2
@@ -275,8 +275,11 @@ spec:
   metrics:
   - type: Pods
     pods:
-      metricName: http_requests
-      targetAverageValue: 10
+        metric:
+          name: http_requests
+        target:
+          type: AverageValue
+          averageValue: 10
 ```
 
 Deploy the `podinfo` HPA in the `default` namespace:

--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ Next define a HPA that maintains a minimum of two replicas and scales up to ten
 if the CPU average is over 80% or if the memory goes over 200Mi:
 
 ```yaml
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: podinfo
 spec:
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: podinfo
   minReplicas: 2
@@ -101,11 +101,15 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: 80
+        target:
+          type: Utilization
+          averageUtilization: 80
   - type: Resource
     resource:
       name: memory
-      targetAverageValue: 200Mi
+        target:
+          type: AverageValue
+          averageValue: 200Mi
 ```
 
 Create the HPA:

--- a/podinfo/podinfo-dep.yaml
+++ b/podinfo/podinfo-dep.yaml
@@ -4,51 +4,54 @@ kind: Deployment
 metadata:
   name: podinfo
 spec:
+  selector:
+    matchLabels:
+      app: podinfo
   replicas: 2
   template:
     metadata:
       labels:
         app: podinfo
       annotations:
-        prometheus.io/scrape: 'true'
+        prometheus.io/scrape: "true"
     spec:
       containers:
-      - name: podinfod
-        image: stefanprodan/podinfo:0.0.1
-        imagePullPolicy: Always
-        command:
-          - ./podinfo
-          - -port=9898
-          - -logtostderr=true
-          - -v=2
-        volumeMounts:
-          - name: metadata
-            mountPath: /etc/podinfod/metadata
-            readOnly: true
-        ports:
-        - containerPort: 9898
-          protocol: TCP
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 9898
-          initialDelaySeconds: 1
-          periodSeconds: 2
-          failureThreshold: 1
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 9898
-          initialDelaySeconds: 1
-          periodSeconds: 3
-          failureThreshold: 2
-        resources:
-          requests:
-            memory: "32Mi"
-            cpu: "1m"
-          limits:
-            memory: "256Mi"
-            cpu: "100m"
+        - name: podinfod
+          image: stefanprodan/podinfo:0.0.1
+          imagePullPolicy: Always
+          command:
+            - ./podinfo
+            - -port=9898
+            - -logtostderr=true
+            - -v=2
+          volumeMounts:
+            - name: metadata
+              mountPath: /etc/podinfod/metadata
+              readOnly: true
+          ports:
+            - containerPort: 9898
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 9898
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            failureThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9898
+            initialDelaySeconds: 1
+            periodSeconds: 3
+            failureThreshold: 2
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "1m"
+            limits:
+              memory: "256Mi"
+              cpu: "100m"
       volumes:
         - name: metadata
           downwardAPI:

--- a/podinfo/podinfo-hpa-custom.yaml
+++ b/podinfo/podinfo-hpa-custom.yaml
@@ -5,13 +5,16 @@ metadata:
   name: podinfo
 spec:
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: podinfo
   minReplicas: 2
   maxReplicas: 10
   metrics:
-  - type: Pods
-    pods:
-      metricName: http_requests
-      targetAverageValue: 10
+    - type: Pods
+      pods:
+        metric:
+          name: http_requests
+        target:
+          type: AverageValue
+          averageValue: 10

--- a/podinfo/podinfo-hpa.yaml
+++ b/podinfo/podinfo-hpa.yaml
@@ -5,17 +5,21 @@ metadata:
   name: podinfo
 spec:
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: podinfo
   minReplicas: 2
   maxReplicas: 10
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      targetAverageUtilization: 80
-  - type: Resource
-    resource:
-      name: memory
-      targetAverageValue: 200Mi
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: AverageValue
+          averageValue: 200Mi


### PR DESCRIPTION
I've tried following the README with the current Kubernetes version (1.18) on Docker Desktop for Windows under WSL2 Ubuntu distro and ran into some errors.

I've decided to fix those errors and took the liberty of updating the used HPA API version to v2beta2, I believe this PR can be useful for newcomers to the k8s environment.