### PR TITLE
Suggested reduction in RAM so prometheus can start (minikube).

### DIFF
--- a/prometheus/prometheus-dep.yaml
+++ b/prometheus/prometheus-dep.yaml
@@ -30,7 +30,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            memory: 2Gi
+            memory: 0.5Gi
         volumeMounts:
         - mountPath: /etc/prometheus/prometheus.yml
           name: prometheus-config


### PR DESCRIPTION
For some reason my pods scaled to 10 by the time I started prometheus and it failed to start due to RAM shortage in minikube.